### PR TITLE
Speeding up interp for 1D inputs

### DIFF
--- a/notebooks/tf-timeline.ipynb
+++ b/notebooks/tf-timeline.ipynb
@@ -44,7 +44,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WARNING:tensorflow:From /Users/mbedell/miniconda3/envs/wobble/lib/python3.6/site-packages/tensorflow/python/framework/op_def_library.py:263: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
+      "WARNING:tensorflow:From /Users/dforeman/anaconda3/lib/python3.6/site-packages/tensorflow/python/framework/op_def_library.py:263: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
       "Instructions for updating:\n",
       "Colocations handled automatically by placer.\n"
      ]
@@ -67,7 +67,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 150/150 [00:21<00:00,  6.66it/s]\n"
+      "100%|██████████| 150/150 [00:05<00:00, 23.23it/s]\n"
      ]
     }
    ],
@@ -110,7 +110,7 @@
    "source": [
     "fetched_timeline = timeline.Timeline(run_metadata.step_stats)\n",
     "chrome_trace = fetched_timeline.generate_chrome_trace_format()\n",
-    "with open('timeline03.json', 'w') as f:\n",
+    "with open('timeline06.json', 'w') as f:\n",
     "    f.write(chrome_trace)"
    ]
   },

--- a/wobble/interp/interp_op.cc
+++ b/wobble/interp/interp_op.cc
@@ -23,11 +23,9 @@ REGISTER_OP("Interp")
     TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(1), 1, &x));
     TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(2), 1, &y));
 
-    TF_RETURN_IF_ERROR(c->Merge(x, y, &x));
-
-    TF_RETURN_IF_ERROR(c->Subshape(t, 0, -1, &t));
-    TF_RETURN_IF_ERROR(c->Subshape(x, 0, -1, &x));
-    TF_RETURN_IF_ERROR(c->Merge(t, x, &t));
+    // The final dimension of x and y must match
+    shape_inference::DimensionHandle dx = c->Dim(x, -1), dy = c->Dim(y, -1);
+    TF_RETURN_IF_ERROR(c->Merge(dx, dy, &dx));
 
     c->set_output(0, c->input(0));
     c->set_output(1, c->input(0));
@@ -40,7 +38,7 @@ class InterpOpBase : public OpKernel {
   explicit InterpOpBase (OpKernelConstruction* context) : OpKernel(context) {}
 
   virtual void DoCompute (OpKernelContext* context,
-    int64 size,
+    bool x_one_d, bool y_one_d, int64 size,
     int M, const T* const x, const T* const y,
     int N, const T* const t, T* v, int* inds) = 0;
 
@@ -54,23 +52,32 @@ class InterpOpBase : public OpKernel {
     int64 ndim = t_tensor.dims();
     OP_REQUIRES(context, ndim >= 1,
         errors::InvalidArgument("t must be at least 1D"));
-    OP_REQUIRES(context, x_tensor.dims() == ndim,
-        errors::InvalidArgument("x and t must have the same number of dimensions"));
-    OP_REQUIRES(context, y_tensor.shape() == x_tensor.shape(),
-        errors::InvalidArgument("x and y must be the same shape"));
+
+    bool x_one_d = x_tensor.dims() == 1;
+    bool y_one_d = y_tensor.dims() == 1;
+    OP_REQUIRES(context, (x_tensor.dims() == ndim) || x_one_d,
+        errors::InvalidArgument("x and t must have the same number of dimensions or x must be 1D"));
+    OP_REQUIRES(context, (y_tensor.dims() == ndim) || y_one_d,
+        errors::InvalidArgument("y and t must have the same number of dimensions or y must be 1D"));
+
+    bool outer = y_tensor.dim_size(y_tensor.dims() - 1) == x_tensor.dim_size(x_tensor.dims() - 1);
+    OP_REQUIRES(context, ((x_one_d || y_one_d) && outer) || (x_tensor.shape() == y_tensor.shape()),
+        errors::InvalidArgument("x and y must be the same outer dimension"));
 
     // Compute the full size of the inner dimensions
     int64 size = 1;
     for (int64 k = 0; k < ndim - 1; ++k) {
       int64 dim = t_tensor.dim_size(k);
       size *= dim;
-      OP_REQUIRES(context, x_tensor.dim_size(k) == dim,
+      OP_REQUIRES(context, x_one_d || (x_tensor.dim_size(k) == dim),
+          errors::InvalidArgument("incompatible dimensions"));
+      OP_REQUIRES(context, y_one_d || (y_tensor.dim_size(k) == dim),
           errors::InvalidArgument("incompatible dimensions"));
     }
 
     // The outer dimensions
     const int64 N = t_tensor.dim_size(ndim - 1);
-    const int64 M = x_tensor.dim_size(ndim - 1);
+    const int64 M = x_tensor.dim_size(x_tensor.dims() - 1);
     OP_REQUIRES(context, N <= tensorflow::kint32max,
         errors::InvalidArgument("too many elements in tensor"));
     OP_REQUIRES(context, M <= tensorflow::kint32max,
@@ -90,14 +97,12 @@ class InterpOpBase : public OpKernel {
     auto inds    = inds_tensor->flat_inner_dims<int, 2>();
 
     DoCompute(context,
-      size,
+      x_one_d, y_one_d, size,
       M, x.data(), y.data(),
       N, t.data(), v.data(), inds.data()
     );
   }
 };
-
-
 
 template <class Device, typename T>
 class InterpOp;
@@ -109,7 +114,7 @@ class InterpOp<CPUDevice, T> : public InterpOpBase<T> {
     explicit InterpOp (OpKernelConstruction* context) : InterpOpBase<T>(context) {}
 
     void DoCompute (OpKernelContext* ctx,
-      int64 size,
+      bool x_one_d, bool y_one_d, int64 size,
       int M, const T* const x, const T* const y,
       int N, const T* const t, T* v, int* inds
     ) override {
@@ -118,7 +123,9 @@ class InterpOp<CPUDevice, T> : public InterpOpBase<T> {
         for (int i = begin; i < end; ++i) {
           int k = i / N;
           int off_m = k * M;
-          inds[i] = interp::interp1d(M, x + off_m, y + off_m, t[i], v + i);
+          int off_x = (x_one_d) ? 0 : off_m;
+          int off_y = (y_one_d) ? 0 : off_m;
+          inds[i] = interp::interp1d(M, x + off_x, y + off_y, t[i], v + i);
         }
       };
 
@@ -128,7 +135,6 @@ class InterpOp<CPUDevice, T> : public InterpOpBase<T> {
     }
 
 };
-
 
 #define REGISTER_CPU(type)                                                 \
   REGISTER_KERNEL_BUILDER(                                                 \

--- a/wobble/interp/interp_rev_op.cc
+++ b/wobble/interp/interp_rev_op.cc
@@ -23,16 +23,14 @@ REGISTER_OP("InterpRev")
     TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(3), 1, &inds));
     TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(4), 1, &bv));
 
-    TF_RETURN_IF_ERROR(c->Merge(x, y, &x));
     TF_RETURN_IF_ERROR(c->Merge(t, inds, &t));
     TF_RETURN_IF_ERROR(c->Merge(t, bv, &t));
 
-    TF_RETURN_IF_ERROR(c->Subshape(t, 0, -1, &t));
-    TF_RETURN_IF_ERROR(c->Subshape(x, 0, -1, &x));
-    TF_RETURN_IF_ERROR(c->Merge(t, x, &t));
+    shape_inference::DimensionHandle dx = c->Dim(x, -1), dy = c->Dim(y, -1);
+    TF_RETURN_IF_ERROR(c->Merge(dx, dy, &dx));
 
     c->set_output(0, c->input(0));
-    c->set_output(1, c->input(1));
+    c->set_output(1, c->input(2));
     return Status::OK();
   });
 
@@ -53,27 +51,36 @@ class InterpRevOp : public OpKernel {
     int64 ndim = t_tensor.dims();
     OP_REQUIRES(context, ndim >= 1,
         errors::InvalidArgument("t must be at least 1D"));
-    OP_REQUIRES(context, x_tensor.dims() == ndim,
-        errors::InvalidArgument("x and t must have the same number of dimensions"));
-    OP_REQUIRES(context, y_tensor.shape() == x_tensor.shape(),
-        errors::InvalidArgument("x and y must be the same shape"));
     OP_REQUIRES(context, t_tensor.shape() == inds_tensor.shape(),
         errors::InvalidArgument("t and inds must be the same shape"));
     OP_REQUIRES(context, t_tensor.shape() == bv_tensor.shape(),
         errors::InvalidArgument("t and bv must be the same shape"));
+
+    bool x_one_d = x_tensor.dims() == 1;
+    bool y_one_d = y_tensor.dims() == 1;
+    OP_REQUIRES(context, (x_tensor.dims() == ndim) || x_one_d,
+        errors::InvalidArgument("x and t must have the same number of dimensions or x must be 1D"));
+    OP_REQUIRES(context, (y_tensor.dims() == ndim) || y_one_d,
+        errors::InvalidArgument("y and t must have the same number of dimensions or y must be 1D"));
+
+    bool outer = y_tensor.dim_size(y_tensor.dims() - 1) == x_tensor.dim_size(x_tensor.dims() - 1);
+    OP_REQUIRES(context, ((x_one_d || y_one_d) && outer) || (x_tensor.shape() == y_tensor.shape()),
+        errors::InvalidArgument("x and y must be the same outer dimension"));
 
     // Compute the full size of the inner dimensions
     int64 size = 1;
     for (int64 k = 0; k < ndim - 1; ++k) {
       int64 dim = t_tensor.dim_size(k);
       size *= dim;
-      OP_REQUIRES(context, x_tensor.dim_size(k) == dim,
+      OP_REQUIRES(context, x_one_d || (x_tensor.dim_size(k) == dim),
+          errors::InvalidArgument("incompatible dimensions"));
+      OP_REQUIRES(context, y_one_d || (y_tensor.dim_size(k) == dim),
           errors::InvalidArgument("incompatible dimensions"));
     }
 
     // The outer dimensions
     const int64 N = t_tensor.dim_size(ndim - 1);
-    const int64 M = x_tensor.dim_size(ndim - 1);
+    const int64 M = x_tensor.dim_size(x_tensor.dims() - 1);
     OP_REQUIRES(context, N <= tensorflow::kint32max,
         errors::InvalidArgument("too many elements in tensor"));
     OP_REQUIRES(context, M <= tensorflow::kint32max,
@@ -98,20 +105,21 @@ class InterpRevOp : public OpKernel {
     by.setConstant(0.0);
 
     for (int64 k = 0; k < size; ++k) {
+      int64 ky = (y_one_d) ? 0 : k;
       for (int64 n = 0; n < N; ++n) {
         T value = t(k, n);
         int ind = inds(k, n);
         if (ind <= 0) {
-          by(k, 0) += bv(k, n);
+          by(ky, 0) += bv(k, n);
         } else if (ind >= M) {
-          by(k, M-1) += bv(k, n);
+          by(ky, M-1) += bv(k, n);
         } else {
           T factor = 1.0 / (x(k, ind) - x(k, ind-1));
           T a = (value - x(k, ind-1)) * factor;
           T bvalue = bv(k, n) * (y(k, ind) - y(k, ind-1)) * factor;
           bt(k, n)     += bvalue;
-          by(k, ind)   += bv(k, n) * a;
-          by(k, ind-1) += bv(k, n) * (1.0 - a);
+          by(ky, ind)   += bv(k, n) * a;
+          by(ky, ind-1) += bv(k, n) * (1.0 - a);
         }
       }
     }


### PR DESCRIPTION
This gets rid of a few additions and multiplications by removing the reshaping shenanigans. I found that this sped things up a little bit on my machine, but it was already about an order of magnitude faster on my laptop than on yours :-).

(Note: most of the diffs here are caused by my editor automatically removing whitespace from the ends of lines.)