### PR TITLE
wobble audio link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## wobble *(/wäb.lā/)* <a href='http://astro.uchicago.edu/~bmontet/wobble.mp3'>:sound:</a>
+## wobble *(/wäb.lā/)* <a href='https://benmontet.github.io/assets/wobble.mp3'>:sound:</a>
 
 [![Documentation Status](https://readthedocs.org/projects/wobble/badge/?version=latest)](https://wobble.readthedocs.io/en/latest/?badge=latest)[![arXiv](https://img.shields.io/badge/arXiv-1901.00503-orange.svg)](https://arxiv.org/abs/1901.00503)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 .. image:: wobble.png
 	:align: center
 
-*wobble* (pronounced `*(/wäb.lā/)* <http://astro.uchicago.edu/~bmontet/wobble.mp3>`_) is an open-source python implementation of a data-driven method for deriving stellar spectra, telluric spectra, and extremely precise radial velocities simultaneously without reliance on spectral models.
+*wobble* (pronounced `*(/wäb.lā/)* <https://benmontet.github.io/assets/wobble.mp3>`_) is an open-source python implementation of a data-driven method for deriving stellar spectra, telluric spectra, and extremely precise radial velocities simultaneously without reliance on spectral models.
 
 Read the paper `on arXiv <https://arxiv.org/abs/1901.00503>`_.
 


### PR DESCRIPTION
My uchicago website doesn't exist any more. This very important PR updates the link for the wobble audio guide to my github page. It seems to work the way I intend it to!