### PR TITLE
Chromatic RV Index Implementation

### DIFF
--- a/wobble/results.py
+++ b/wobble/results.py
@@ -392,7 +392,7 @@ class Results(object):
         plt.savefig(filename)
         plt.close(fig)
         
-    def plot_chromatic_rvs(self, min_order=None, max_order=None, percentiles=(16,84), wavelengths=None, scale='log',  ylim=None, center=True):
+    def plot_chromatic_rvs(self, min_order=None, max_order=None, percentiles=(16,84), wavelengths=None, scale='log',  ylim=None, center=True, filename=None):
         """Output a representative percentile plot showing the chromaticity apparent in the rv signal.
         
         Parameters
@@ -411,6 +411,8 @@ class Results(object):
                     Optional ylim; passed to matplotlib.
         center : 'boolean' 
                     Determines whether the epochs are median centered before percentiles are calculated. 
+        filename : 'str'
+                    Saves plot if given. Optional filename; passed to matplotlib e.g. 'filename.png'
    	"""
         if min_order == None:
             min_order = 0
@@ -433,18 +435,20 @@ class Results(object):
         m2, b2 = np.polyfit(x, lower, 1)
         plt.errorbar(x, upper, upper_sigma, fmt='o')
         plt.errorbar(x, lower, lower_sigma, fmt='o')
-        plt.plot(x, m*x + b)
-        plt.plot(x, m2*x + b2)
+        plt.plot(x, m*x + b, color='tab:blue')
+        plt.plot(x, m2*x + b2, color='tab:orange')
         plt.ylabel('Radial Velocity [m/s]')
         plt.xlabel('Wavelength λ [Å]')
         plt.ylim(ylim)
         plt.xscale(scale)
-        plt.savefig('chromatic rvs.png')
+        if filename != None:
+            plt.savefig(filename)
         plt.show()
+        
         
     
     def chromatic_index(self, min_order=None, max_order=None, wavelengths=None):
-        """ Return the chromatic index for each epoch (slope of the linear least squares fit).
+        """ Returns a 2 by no. of epochs array representing the chromatic index along with uncertainty for each epoch (calculated as slope of the linear least squares fit).
         
         Parameters
         ----------
@@ -465,7 +469,9 @@ class Results(object):
             orders = ((x > int(wavelengths[0])) & (x < int(wavelengths[1])))
             x = x[orders]
         chromatic_indices = []
+        sigmas = []
         for epoch in range(len(self.epochs)): 
-           m, b = np.polyfit(x, np.array(self.star_rvs)[orders, epoch], 1)
-           chromatic_indices.append(m)
-        return(chromatic_indices)
+           coefs = np.polyfit(x, np.array(self.star_rvs)[orders, epoch], 1, full=True)
+           chromatic_indices.append(coefs[0][0])
+           sigmas.append(np.sqrt(coefs[1][0]))
+        return([chromatic_indices, sigmas])

--- a/wobble/results.py
+++ b/wobble/results.py
@@ -436,7 +436,7 @@ class Results(object):
         plt.show(f)
     
     def chromatic_index(self, min_order=None, max_order=None, wavelengths=None):
-        """ Return the chromatic index for each epoch (slope of the linear least squares fit).
+        """Return the chromatic index for each epoch (slope of the linear least squares fit).
         
         Parameters
         ----------

--- a/wobble/results.py
+++ b/wobble/results.py
@@ -411,9 +411,9 @@ class Results(object):
                     Optional ylim; passed to matplotlib.
    	    """
         if min_order == None:
-            min_order = min(self.orders)
+            min_order = 0
         if max_order == None:
-            max_order = max(self.orders)
+            max_order = len(self.orders)
         upper = np.percentile(self.star_rvs[min_order:max_order], percentiles[1], axis=1)
         lower = np.percentile(self.star_rvs[min_order:max_order], percentiles[0], axis=1)
         x = np.array([np.exp(np.mean(order)) for order in self.star_template_xs[min_order:max_order]])

--- a/wobble/results.py
+++ b/wobble/results.py
@@ -451,7 +451,7 @@ class Results(object):
             max_order = max(self.orders)
         x = np.array([np.mean(order) for order in self.star_template_xs[min_order:max_order]])
         chromatic_indices = []
-        for epoch in self.epochs: 
+        for epoch in range(len(self.epochs)): 
            m, b = np.polyfit(x, np.array(self.star_rvs)[min_order:max_order,epoch], 1)
            chromatic_indices.append(m)
         return(chromatic_indices)

--- a/wobble/results.py
+++ b/wobble/results.py
@@ -448,7 +448,7 @@ class Results(object):
         
     
     def chromatic_index(self, min_order=None, max_order=None, wavelengths=None):
-        """ Returns a 2 by no. of epochs array representing the chromatic index along with uncertainty for each epoch (calculated as slope of the linear least squares fit).
+        """ Returns a 2 by n array representing the chromatic index along with uncertainty for each epoch (calculated as slope of the linear least squares fit).
         
         Parameters
         ----------
@@ -463,7 +463,7 @@ class Results(object):
             min_order = 0
         if max_order == None:
             max_order = len(self.orders)
-        orders = np.arange(min_order,max_order)
+        orders = np.arange(min_order, max_order)
         x = np.array([np.mean(order) for order in self.star_template_xs[min_order:max_order]])
         if wavelengths != None:
             orders = ((x > int(wavelengths[0])) & (x < int(wavelengths[1])))
@@ -474,4 +474,4 @@ class Results(object):
            coefs = np.polyfit(x, np.array(self.star_rvs)[orders, epoch], 1, full=True)
            chromatic_indices.append(coefs[0][0])
            sigmas.append(np.sqrt(coefs[1][0]))
-        return([chromatic_indices, sigmas])
+        return [chromatic_indices, sigmas]

--- a/wobble/results.py
+++ b/wobble/results.py
@@ -433,10 +433,13 @@ class Results(object):
         lower_sigma = np.sqrt(1/np.array(self.star_ivars_rvs))[orders, np.argmin(abs(np.array(self.star_rvs)[orders].T - lower.T).T, axis=1)]
         m, b = np.polyfit(x, upper, 1)
         m2, b2 = np.polyfit(x, lower, 1)
+        y = m*x + b
+        y2 = m2*x + b2
         plt.errorbar(x, upper, upper_sigma, fmt='o')
         plt.errorbar(x, lower, lower_sigma, fmt='o')
-        plt.plot(x, m*x + b, color='tab:blue')
-        plt.plot(x, m2*x + b2, color='tab:orange')
+        plt.plot(x, y, color='tab:blue')
+        plt.plot(x, y2, color='tab:orange')
+        plt.fill_between(x, y, y2, color='lightgray')
         plt.ylabel('Radial Velocity [m/s]')
         plt.xlabel('Wavelength λ [Å]')
         plt.ylim(ylim)


### PR DESCRIPTION
Implementing chromatic_index function calculating chromatic index / uncertainty for each epoch.
Also defining plot_chromatic_rvs, which plots the 16th and 84th RV percentiles (by default) for each order - examples below. 

K2-100 (orders 15 - 45)
![K2-100 chromatic index - orders 15 - 45](https://user-images.githubusercontent.com/74441417/104809589-89ec9080-5842-11eb-8d31-949bd7d913db.png)
51 Pegasi (all orders)
![51 Pegasi percentile plot](https://user-images.githubusercontent.com/74441417/104809641-cddf9580-5842-11eb-8246-2905c2f11063.png)

